### PR TITLE
Add option to ignore.

### DIFF
--- a/transcribe/transcribe.py
+++ b/transcribe/transcribe.py
@@ -25,13 +25,13 @@ class Transcriber:
         for dirpath, dirnames, filenames in os.walk(self.output):
             for filename in filenames:
                 if filename.endswith('.vtt'):
-                    existing.append(os.path.splitext(filename)[0])
+                    existing.append(f'{os.path.splitext(filename)[0]}_{self.model}')
         return existing
 
     def batch_transcribe(self):
         for dirpath, dirnames, filenames in os.walk(self.directory):
             for filename in tqdm(filenames):
-                if os.path.splitext(filename)[0] not in self.existing:
+                if f'{os.path.splitext(filename)[0]}_{self.model}' not in self.existing:
                     self.__transcribe(os.path.join(self.directory, filename))
         return
 

--- a/transcribe/transcribe.py
+++ b/transcribe/transcribe.py
@@ -8,17 +8,31 @@ import whisper
 from whisper.utils import get_writer
 
 class Transcriber:
-    def __init__(self, directory, output, language_model, language, fp16):
+    def __init__(self, directory, output, language_model, language, fp16, ignore_existing=False):
         self.directory = directory
         self.output = output
         self.model = language_model
         self.language = language
         self.fp16 = fp16
+        self.ignore_existing = ignore_existing
+        if self.ignore_existing:
+            self.existing = self.__cache_existing()
+        else:
+            self.existing = []
+
+    def __cache_existing(self):
+        existing = []
+        for dirpath, dirnames, filenames in os.walk(self.output):
+            for filename in filenames:
+                if filename.endswith('.vtt'):
+                    existing.append(os.path.splitext(filename)[0])
+        return existing
 
     def batch_transcribe(self):
         for dirpath, dirnames, filenames in os.walk(self.directory):
             for filename in tqdm(filenames):
-                self.__transcribe(os.path.join(self.directory, filename))
+                if os.path.splitext(filename)[0] not in self.existing:
+                    self.__transcribe(os.path.join(self.directory, filename))
         return
 
     def __transcribe(self, file):
@@ -39,6 +53,7 @@ if __name__ == "__main__":
                         choices=['tiny', 'base', 'small', 'medium', 'large'])
     parser.add_argument('-l', '--language', help='Specify language', default='English')
     parser.add_argument('-f', '--fp16', action='store_true', help='Use FP16 instead of FP32')
+    parser.add_argument('-i', '--ignore_existing', action='store_true', help='Ignore A/V files that already have a transcription')
     args = parser.parse_args()
-    x = Transcriber(args.directory, args.output, args.model, args.language, args.fp16)
+    x = Transcriber(args.directory, args.output, args.model, args.language, args.fp16, args.ignore_existing)
     x.batch_transcribe()

--- a/transcribe/transcribe.py
+++ b/transcribe/transcribe.py
@@ -25,7 +25,7 @@ class Transcriber:
         for dirpath, dirnames, filenames in os.walk(self.output):
             for filename in filenames:
                 if filename.endswith('.vtt'):
-                    existing.append(f'{os.path.splitext(filename)[0]}_{self.model}')
+                    existing.append(f'{os.path.splitext(filename)[0]}')
         return existing
 
     def batch_transcribe(self):


### PR DESCRIPTION
# What Does This Do

Adds an option to ignore files that have already been processed.

# How Does it Work

If someone includes `-i` or `--ignore_existing` in their request, matching files will not be processed.  

This works by telling the class to look for whether someone has done this, and if so, caching the filenames in the `self.existing` property.  We then check to see what filenames are in the property before we run each time.